### PR TITLE
[#22] feat: 카테고리 별 페이지네이션 도서 조회 API 기능 추가

### DIFF
--- a/server/src/main/java/kr/codesquad/library/controller/BookSearchController.java
+++ b/server/src/main/java/kr/codesquad/library/controller/BookSearchController.java
@@ -6,8 +6,7 @@ import kr.codesquad.library.domain.book.response.BooksByCategoryResponse;
 import kr.codesquad.library.global.api.ApiResult;
 import kr.codesquad.library.service.BookSearchService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -16,15 +15,25 @@ import static kr.codesquad.library.global.api.ApiResult.OK;
 @RequiredArgsConstructor
 @Api
 @RestController
+@RequestMapping("/v1")
 public class BookSearchController {
 
     private final BookSearchService bookSearchService;
 
     @ApiOperation(value = "메인페이지 API")
-    @GetMapping("/books/main")
+    @GetMapping("/main")
     public ApiResult<List<BooksByCategoryResponse>> getMainBooks() {
 
         return OK(bookSearchService.findMainBooks());
+    }
+
+    @ApiOperation(value = "카테고리별 페이지가져오기")
+    @GetMapping("/category/{categoryId}")
+    public ApiResult<BooksByCategoryResponse> getCategoryBooks(
+            @PathVariable Long categoryId,
+            @RequestParam(value = "page", defaultValue = "1") int page) {
+
+        return OK(bookSearchService.findByCategory(categoryId, page));
     }
 
 }

--- a/server/src/main/java/kr/codesquad/library/domain/book/Book.java
+++ b/server/src/main/java/kr/codesquad/library/domain/book/Book.java
@@ -5,12 +5,14 @@ import kr.codesquad.library.domain.category.Category;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.*;
 import java.time.LocalDate;
 
 import static javax.persistence.FetchType.*;
 
+@ToString
 @NoArgsConstructor
 @Getter
 @Entity

--- a/server/src/main/java/kr/codesquad/library/domain/book/BookRepository.java
+++ b/server/src/main/java/kr/codesquad/library/domain/book/BookRepository.java
@@ -1,10 +1,16 @@
 package kr.codesquad.library.domain.book;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
+    Long countByCategoryId(Long categoryId);
+
     List<Book> findTop6ByCategoryIdAndImageUrlIsNotNullOrderByRecommendCountDesc(Long categoryId);
+
+    Page<Book> findByCategoryIdOrderByPublicationDateDesc(Long categoryId, Pageable pageable);
 }

--- a/server/src/main/java/kr/codesquad/library/domain/book/BookVO.java
+++ b/server/src/main/java/kr/codesquad/library/domain/book/BookVO.java
@@ -1,0 +1,6 @@
+package kr.codesquad.library.domain.book;
+
+public class BookVO {
+
+    public final static int PAGESIZE = 20;
+}

--- a/server/src/main/java/kr/codesquad/library/domain/book/response/BooksByCategoryResponse.java
+++ b/server/src/main/java/kr/codesquad/library/domain/book/response/BooksByCategoryResponse.java
@@ -10,12 +10,14 @@ public class BooksByCategoryResponse {
 
     private final Long categoryId;
     private final String categoryTitle;
+    private final Long bookCount;
     private final List<BookResponse> books;
 
     @Builder
-    public BooksByCategoryResponse(Long categoryId, String categoryTitle, List<BookResponse> books) {
+    public BooksByCategoryResponse(Long categoryId, String categoryTitle, Long bookCount, List<BookResponse> books) {
         this.categoryId = categoryId;
         this.categoryTitle = categoryTitle;
+        this.bookCount = bookCount;
         this.books = books;
     }
 }

--- a/server/src/test/java/kr/codesquad/library/domain/book/BookRepositoryTest.java
+++ b/server/src/test/java/kr/codesquad/library/domain/book/BookRepositoryTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 
 import javax.transaction.Transactional;
@@ -64,5 +66,19 @@ class BookRepositoryTest {
 
         List<Book> MobileBooks = books.findTop6ByCategoryIdAndImageUrlIsNotNullOrderByRecommendCountDesc(1L);
         assertThat(MobileBooks.get(0).getTitle()).isEqualTo(book.getTitle());
+    }
+
+    @CsvSource({"0, 20, 1"})
+    @ParameterizedTest
+    public void 첫번째_카테고리페이지가져오기(int page, int size, Long categoryId) {
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        Page<Book> page1 = books.findByCategoryIdOrderByPublicationDateDesc(categoryId, pageRequest);
+
+        assertThat(page1.getTotalElements()).isEqualTo(39);
+        assertThat(page1.getTotalPages()).isEqualTo(2);
+        assertThat(page1.getNumber()).isEqualTo(page);
+        assertThat(page1.getSize()).isEqualTo(size);
     }
 }

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,17 +1,18 @@
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;
-    username: sa
-    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/test?useUnicode=yes&serverTimezone=UTC&characterEncoding=UTF-8
+    username: admin
+    password: tiger
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.MySQL57InnoDBDialect
+    open-in-view: false
+    show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
-    show-sql: true
 
 logging:
   level:


### PR DESCRIPTION
- BookSearchController
  - getMainBooks(): API 문서에 맞춰 url 변경.
  - getCategoryBooks(): 카테고리 Id에 따른 페이지네이션 컨트롤러. RequestParam으로 query를 넣지 않으면 기본페이지는 1.

- BookByCategoryResponse: 카테고리 별 도서 재고숫자 추가

- BookRepository
  - countByCategoryId(): 페이지네이션 하면서 Count하기 때문에 추가할 필요없는 쿼리. 추후에 삭제될 예정.
  - findByCategoryIdOrderByPublicationDateDesc(): 기존의 findTop6ByCategoryId 쿼리와 속성이 비슷하여 중복코드에 해당. 추후에 리팩토링 예정.

- BookVO: Page Size를 위한 VO. Bean으로 등록할 수도 있음.

- BookSearchService
  - findTop6BooksAndCategoryById(): 카테고리별 도서 갯수 추가.
  - findByCategory(): 카테고리별 도서 Dto생성.
  - findByCategoryIdBooks(): 카테고리 별 페이지에 맞게 도서데이터를 가져옴.

하나의 메소드에 쿼리를 너무 많이 날려서 리팩토링을 통해 줄이도록 할 것.
예외처리도 필요함.