### PR TITLE
[#51] feat: 도서 제목으로 검색 기능 추가

### DIFF
--- a/server/src/main/java/kr/codesquad/library/controller/BookSearchController.java
+++ b/server/src/main/java/kr/codesquad/library/controller/BookSearchController.java
@@ -3,6 +3,7 @@ package kr.codesquad.library.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import kr.codesquad.library.domain.book.response.BookDetailResponse;
+import kr.codesquad.library.domain.book.response.BookResponse;
 import kr.codesquad.library.domain.book.response.BooksByCategoryResponse;
 import kr.codesquad.library.global.api.ApiResult;
 import kr.codesquad.library.service.BookSearchService;
@@ -23,6 +24,8 @@ import static kr.codesquad.library.global.api.ApiResult.OK;
 @RequestMapping("/v1")
 public class BookSearchController {
 
+    private static final int PAGE_MINIMUM = 1;
+
     private final BookSearchService bookSearchService;
 
     @ApiOperation(value = "메인페이지")
@@ -36,7 +39,7 @@ public class BookSearchController {
     @GetMapping("/category/{categoryId}")
     public ResponseEntity<ApiResult<BooksByCategoryResponse>> getCategoryBooks(
             @PathVariable Long categoryId,
-            @RequestParam(value = "page", defaultValue = "1") @Min(1) int page) {
+            @RequestParam(value = "page", defaultValue = "1") @Min(PAGE_MINIMUM) int page) {
 
         return ResponseEntity.ok(OK(bookSearchService.findByCategory(categoryId, page)));
     }
@@ -48,4 +51,12 @@ public class BookSearchController {
         return ResponseEntity.ok(OK(bookSearchService.findByBookId(bookId)));
     }
 
+    @ApiOperation(value = "도서 검색페이지")
+    @GetMapping("/search")
+    public ResponseEntity<ApiResult<List<BookResponse>>> searchBooks
+            (@RequestParam(value = "q") String title,
+             @RequestParam(value = "page", defaultValue = "1") @Min(PAGE_MINIMUM) int page) {
+
+        return ResponseEntity.ok(OK(bookSearchService.searchBooks(title, page)));
+    }
 }

--- a/server/src/main/java/kr/codesquad/library/domain/book/BookRepository.java
+++ b/server/src/main/java/kr/codesquad/library/domain/book/BookRepository.java
@@ -11,4 +11,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     Page<Book> findByCategoryId(Long categoryId, Pageable pageable);
 
     List<Book> findTop6ByCategoryIdAndImageUrlIsNotNullOrderByRecommendCountDesc(Long categoryId);
+
+    Page<Book> findByTitleContaining(String title, Pageable pageable);
 }

--- a/server/src/main/java/kr/codesquad/library/service/BookSearchService.java
+++ b/server/src/main/java/kr/codesquad/library/service/BookSearchService.java
@@ -69,9 +69,7 @@ public class BookSearchService {
     }
 
     public List<BookResponse> findByCategoryIdBooks(Long categoryId, int page) {
-        Sort sort = Sort.by(Sort.Direction.DESC, "publicationDate");
-        PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE, sort);
-        Page<Book> bookPage = bookRepository.findByCategoryId(categoryId, pageRequest);
+        Page<Book> bookPage = bookRepository.findByCategoryId(categoryId, getPageRequest(page));
         List<Book> bookList = bookPage.getContent();
 
         return bookList.stream().map(BookResponse::of).collect(Collectors.toList());
@@ -85,4 +83,15 @@ public class BookSearchService {
         return BookDetailResponse.of(findBook, rental);
     }
 
+    public List<BookResponse> searchBooks(String title, int page) {
+        Page<Book> bookPage = bookRepository.findByTitleContaining(title, getPageRequest(page));
+        List<Book> bookList = bookPage.getContent();
+
+        return bookList.stream().map(BookResponse::of).collect(Collectors.toList());
+    }
+
+    private PageRequest getPageRequest(int page) {
+        Sort sort = Sort.by(Sort.Direction.DESC, "publicationDate");
+        return PageRequest.of(page - 1, PAGE_SIZE, sort);
+    }
 }

--- a/server/src/test/java/kr/codesquad/library/domain/book/BookRepositoryTest.java
+++ b/server/src/test/java/kr/codesquad/library/domain/book/BookRepositoryTest.java
@@ -72,8 +72,7 @@ class BookRepositoryTest {
     @CsvSource({"0, 20, 1, publicationDate"})
     @ParameterizedTest
     public void 첫번째_카테고리페이지가져오기(int page, int size, Long categoryId, String property) {
-        Sort sort = Sort.by(Sort.Direction.DESC, property);
-        PageRequest pageRequest = PageRequest.of(page, size, sort);
+        PageRequest pageRequest = getPageRequest(page, size, property);
 
         Page<Book> page1 = books.findByCategoryId(categoryId, pageRequest);
 
@@ -81,5 +80,38 @@ class BookRepositoryTest {
         assertThat(page1.getTotalPages()).isEqualTo(2);
         assertThat(page1.getNumber()).isEqualTo(page);
         assertThat(page1.getSize()).isEqualTo(size);
+    }
+
+    @CsvSource({"0, 20, publicationDate, java"})
+    @ParameterizedTest
+    public void 도서검색_리스트가져오기(int page, int size, String property, String title) throws Exception {
+        //given
+        PageRequest pageRequest = getPageRequest(page, size, property);
+
+        //when
+        Page<Book> page1 = books.findByTitleContaining(title, pageRequest);
+        List<Book> bookList = page1.getContent();
+
+        //then
+        assertThat(bookList).isNotEmpty();
+    }
+
+    @CsvSource({"0, 20, publicationDate, 롯데"})
+    @ParameterizedTest
+    public void 검색_실패(int page, int size, String property, String title) throws Exception {
+        //given
+        PageRequest pageRequest = getPageRequest(page, size, property);
+
+        //when
+        Page<Book> page1 = books.findByTitleContaining(title, pageRequest);
+        List<Book> bookList = page1.getContent();
+
+        //then
+        assertThat(bookList).isEmpty();
+    }
+
+    private PageRequest getPageRequest(int page, int size, String property) {
+        Sort sort = Sort.by(Sort.Direction.DESC, property);
+        return PageRequest.of(page, size, sort);
     }
 }


### PR DESCRIPTION
- BookSearchController
  - PAGE_MINIMUM: 중복이 있어 따로 필드로 값을 뺌.
  - searchBooks(): 임시로 타이틀로만 검색 수 있도록 설정. 추후에 저자,
  출판사, 발행일자 조회가 되도록 살 것.

- BookRepository

- BookSearchService
  - getPageRequest(): 중복되는 메서드로 리팩토링함. 그러나, PageRequest를 여러군데 사용시 따로 클래스로 만들어 관리할 수도 있음.

- BookRepositoryTest: 간단한 검색이라 Repository 테스트로만 확인.