### PR TITLE
[#71] refactor: 3차 PR바탕으로 코드 리팩토링

### DIFF
--- a/server/src/main/java/kr/codesquad/library/controller/BookSearchController.java
+++ b/server/src/main/java/kr/codesquad/library/controller/BookSearchController.java
@@ -8,7 +8,6 @@ import kr.codesquad.library.domain.book.response.BooksByCategoryResponse;
 import kr.codesquad.library.global.api.ApiResult;
 import kr.codesquad.library.service.BookSearchService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,39 +23,39 @@ import static kr.codesquad.library.global.api.ApiResult.OK;
 @RequestMapping("/v1")
 public class BookSearchController {
 
-    private static final int PAGE_MINIMUM = 1;
+    private final int PAGE_MINIMUM = 1;
 
     private final BookSearchService bookSearchService;
 
     @ApiOperation(value = "메인페이지")
     @GetMapping("/main")
-    public ResponseEntity<ApiResult<List<BooksByCategoryResponse>>> getMainBooks() {
+    public ApiResult<List<BooksByCategoryResponse>> getMainBooks() {
 
-        return ResponseEntity.ok(OK(bookSearchService.findMainBooks()));
+        return OK(bookSearchService.findMainBooks());
     }
 
     @ApiOperation(value = "카테고리별 페이지가져오기")
     @GetMapping("/category/{categoryId}")
-    public ResponseEntity<ApiResult<BooksByCategoryResponse>> getCategoryBooks(
+    public ApiResult<BooksByCategoryResponse> getCategoryBooks(
             @PathVariable Long categoryId,
             @RequestParam(value = "page", defaultValue = "1") @Min(PAGE_MINIMUM) int page) {
 
-        return ResponseEntity.ok(OK(bookSearchService.findByCategory(categoryId, page)));
+        return OK(bookSearchService.findByCategory(categoryId, page));
     }
 
     @ApiOperation(value = "도서 상세페이지")
     @GetMapping("/books/{bookId}")
-    public ResponseEntity<ApiResult<BookDetailResponse>> getBookDetail(@PathVariable Long bookId) {
+    public ApiResult<BookDetailResponse> getBookDetail(@PathVariable Long bookId) {
 
-        return ResponseEntity.ok(OK(bookSearchService.findByBookId(bookId)));
+        return OK(bookSearchService.findByBookId(bookId));
     }
 
     @ApiOperation(value = "도서 검색페이지")
     @GetMapping("/search")
-    public ResponseEntity<ApiResult<BookSearchResponse>> searchBooks(
+    public ApiResult<BookSearchResponse> searchBooks(
             @RequestParam(value = "q") String title,
             @RequestParam(value = "page", defaultValue = "1") @Min(PAGE_MINIMUM) int page) {
 
-        return ResponseEntity.ok(OK(bookSearchService.searchBooks(title, page)));
+        return OK(bookSearchService.searchBooks(title, page));
     }
 }

--- a/server/src/main/java/kr/codesquad/library/domain/account/Account.java
+++ b/server/src/main/java/kr/codesquad/library/domain/account/Account.java
@@ -18,13 +18,13 @@ public class Account {
     @Column(name = "account_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(nullable = false, unique = true)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Column(name = "library_role", nullable = false, columnDefinition = "varchar(64) default 'GUEST'")
+    @Column(name = "library_role", nullable = false)
     @Enumerated(STRING)
     private LibraryRole libraryRole;
 
@@ -35,12 +35,11 @@ public class Account {
         this.libraryRole = libraryRole;
     }
 
-    public Account changeRole(LibraryRole libraryRole) {
+    public void changeRole(LibraryRole libraryRole) {
         this.libraryRole = libraryRole;
-        return this;
     }
 
-    public Account update(String name) {
+    public Account updateName(String name) {
         this.name = name;
         return this;
     }

--- a/server/src/main/java/kr/codesquad/library/domain/book/Book.java
+++ b/server/src/main/java/kr/codesquad/library/domain/book/Book.java
@@ -38,7 +38,6 @@ public class Book {
 
     private String isbn;
 
-    @Column(name = "available")
     private boolean available;
 
     @Column(name = "recommend_count")

--- a/server/src/main/java/kr/codesquad/library/global/config/oauth/service/OAuth2Service.java
+++ b/server/src/main/java/kr/codesquad/library/global/config/oauth/service/OAuth2Service.java
@@ -34,7 +34,7 @@ public class OAuth2Service {
 
     private Account saveOrUpdate(OAuthAttributes attributes) {
         Account account = accountRepository.findByEmail(attributes.getEmail())
-                .map(entry -> entry.update(attributes.getName()))
+                .map(entry -> entry.updateName(attributes.getName()))
                 .orElseGet(attributes::toEntity);
 
         return accountRepository.save(account);

--- a/server/src/main/java/kr/codesquad/library/global/error/ErrorCode.java
+++ b/server/src/main/java/kr/codesquad/library/global/error/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     // BookSearch
     CATEGORY_NOT_FOUND(404, "B001", "해당 카테고리는 없습니다."),
     BOOK_NOT_FOUND(404, "B002", "해당 도서는 없습니다."),
-    NOT_PRESENT_PARAMETER(400, "B03", "q param이 필요합니다."),
+    PARAMETER_NOT_PRESENT(400, "B003", "q param이 필요합니다."),
 
 
     ;

--- a/server/src/main/java/kr/codesquad/library/global/error/GlobalRestExceptionHandler.java
+++ b/server/src/main/java/kr/codesquad/library/global/error/GlobalRestExceptionHandler.java
@@ -49,7 +49,7 @@ public class GlobalRestExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
             MissingServletRequestParameterException e) {
         log.error("handleMissingServletRequestParameterException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.NOT_PRESENT_PARAMETER);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.PARAMETER_NOT_PRESENT);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 


### PR DESCRIPTION
- BookSearchController: ResponseEntity와 ApiResult의 OK가 중복되는 코드. RestController를 사용하면 ResponseEntity는 붙일 필요가 없다는걸 인식하여 삭제함.

- Account: 필드 name 명시, DB에 직접영향을 주는 LibraryRole의 디폴드값 삭제
  - changeRole(): 리턴값을 쓰지 않으므로 void로 변경.
  - updateName(): 이름 명확

- ErrorCode
  - PARAMETER_NOT_PRESENT: 명사 + 동사로 통일성있게 변경.