### PR TITLE
[#52] fix: Security에서 Swagger 허용 코드 추가.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REPOSITORY=/home/ubuntu/server
+REPOSITORY=/home/ubuntu/codesquad-library
 cd $REPOSITORY
 
 APP_NAME=library

--- a/src/main/java/kr/codesquad/library/controller/TestController.java
+++ b/src/main/java/kr/codesquad/library/controller/TestController.java
@@ -1,0 +1,14 @@
+package kr.codesquad.library.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class TestController {
+
+    @GetMapping("/")
+    public String login() {
+
+        return "index";
+    }
+}

--- a/src/main/java/kr/codesquad/library/global/config/SecurityConfig.java
+++ b/src/main/java/kr/codesquad/library/global/config/SecurityConfig.java
@@ -1,10 +1,11 @@
-package kr.codesquad.library.global.config.oauth;
+package kr.codesquad.library.global.config;
 
 import kr.codesquad.library.domain.account.LibraryRole;
 import kr.codesquad.library.global.config.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
@@ -15,18 +16,29 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/v2/api-docs",
+                "/configuration/ui",
+                "/swagger-resources/**",
+                "/configuration/security",
+                "/swagger-ui.html",
+                "/webjars/**");
+    }
+
+    @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
                 .antMatchers("/", "/v1/main", "/v1/category/**", "/v1/search/**", "/v1/oauth/**").permitAll()
                 .antMatchers(HttpMethod.GET, "/v1/books/**").permitAll()
                 .antMatchers(HttpMethod.POST, "/v1/books/**")
-                                            .hasAnyRole(LibraryRole.USER.name(), LibraryRole.ADMIN.name())
+                .hasAnyRole(LibraryRole.USER.name(), LibraryRole.ADMIN.name())
                 .anyRequest().authenticated()
                 .and()
                 .logout()
                 .logoutSuccessUrl("/");
 
         http.oauth2Login()
+                .defaultSuccessUrl("/", true)
                 .userInfoEndpoint()
                 .userService(customOAuth2UserService);
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>login</title>
+</head>
+<body>
+    <h1>로그인페이지</h1>
+<a href="/oauth2/authorization/github" role="button">Github Login</a>
+
+</body>
+</html>


### PR DESCRIPTION
- deploy.sh: 배포 경로 재설정
- SecurityConfig
  - configure(WebSecurity): swagger를 시큐리티에서 무시함.
  - configure(HttpSecurity): OAuth2 로그인 성공 후 성공 url은 메인("/")으로 설정.

- 테스트 하기위한 TestController, index.html 추가