### PR TITLE
[#100] feat: 유저 권한 표시 및 권한 요청 API 추가

### DIFF
--- a/src/main/java/kr/codesquad/library/controller/AccountController.java
+++ b/src/main/java/kr/codesquad/library/controller/AccountController.java
@@ -4,19 +4,19 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import kr.codesquad.library.domain.account.response.AccountMyPageResponse;
 import kr.codesquad.library.domain.account.response.AccountProfileResponse;
+import kr.codesquad.library.domain.account.response.RoleRequestResponse;
 import kr.codesquad.library.global.api.ApiResult;
 import kr.codesquad.library.global.config.oauth.dto.AccountPrincipal;
 import kr.codesquad.library.global.config.resolver.LoginAccount;
 import kr.codesquad.library.global.error.ErrorCode;
 import kr.codesquad.library.global.error.ErrorResponse;
+import kr.codesquad.library.global.error.exception.domain.BadRequestAuthorizationException;
 import kr.codesquad.library.service.AccountService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static kr.codesquad.library.global.api.ApiResult.OK;
 
@@ -41,7 +41,14 @@ public class AccountController {
         return OK(accountService.getProfile(loginAccount.getId()));
     }
 
-    @ExceptionHandler({RuntimeException.class})
+    @ApiOperation(value = "USER 권한 요청")
+    @PutMapping()
+    public ApiResult<RoleRequestResponse> requestAuthority(@LoginAccount AccountPrincipal loginAccount) {
+        return OK(accountService.requestAuthority(loginAccount.getId()));
+    }
+
+    // 로그아웃상태 예외처리
+    @ExceptionHandler({NullPointerException.class})
     public ResponseEntity<ErrorResponse> handleAccountException(final Exception exception) {
         log.info("LogoutException : {}", exception.getMessage());
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.ACCOUNT_LOGOUT);

--- a/src/main/java/kr/codesquad/library/domain/account/Account.java
+++ b/src/main/java/kr/codesquad/library/domain/account/Account.java
@@ -39,21 +39,22 @@ public class Account {
     @Enumerated(STRING)
     private LibraryRole libraryRole;
 
+    @Column(name = "role_request", nullable = false)
+    private boolean roleRequest;
+
     @OneToMany(mappedBy = "account", cascade = ALL)
     private List<Rental> rentals = new ArrayList<>();
 
     @Builder
-    private Account(Long oauthId, String name, String email, LibraryRole libraryRole, String avatarUrl, List<Rental> rentals) {
+    private Account(Long oauthId, String name, String email, String avatarUrl, LibraryRole libraryRole,
+                    boolean roleRequest, List<Rental> rentals) {
         this.oauthId = oauthId;
         this.name = name;
         this.email = email;
-        this.libraryRole = libraryRole;
         this.avatarUrl = avatarUrl;
-        this.rentals = rentals;
-    }
-
-    public void changeRole(LibraryRole libraryRole) {
         this.libraryRole = libraryRole;
+        this.roleRequest = roleRequest;
+        this.rentals = rentals;
     }
 
     public Account update(String name, String avatarUrl) {
@@ -64,6 +65,10 @@ public class Account {
 
     public String getRoleKey() {
         return libraryRole.getKey();
+    }
+
+    public boolean requestUserRole() {
+        return this.roleRequest = true;
     }
 }
 

--- a/src/main/java/kr/codesquad/library/domain/account/response/AccountMyPageResponse.java
+++ b/src/main/java/kr/codesquad/library/domain/account/response/AccountMyPageResponse.java
@@ -1,6 +1,7 @@
 package kr.codesquad.library.domain.account.response;
 
 import kr.codesquad.library.domain.account.Account;
+import kr.codesquad.library.domain.account.LibraryRole;
 import kr.codesquad.library.domain.rental.response.RentalBookResponse;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,13 +14,18 @@ public class AccountMyPageResponse {
     private final String name;
     private final String email;
     private final String avatarUrl;
+    private final LibraryRole role;
+    private final boolean requested;
     private final List<RentalBookResponse> rentalBookResponses;
 
     @Builder
-    private AccountMyPageResponse(String name, String email, String avatarUrl, List<RentalBookResponse> rentalBookResponses) {
+    private AccountMyPageResponse(String name, String email, String avatarUrl, LibraryRole role,
+                                  boolean requested, List<RentalBookResponse> rentalBookResponses) {
         this.name = name;
         this.email = email;
         this.avatarUrl = avatarUrl;
+        this.role = role;
+        this.requested = requested;
         this.rentalBookResponses = rentalBookResponses;
     }
 
@@ -28,6 +34,8 @@ public class AccountMyPageResponse {
                 .name(account.getName())
                 .email(account.getEmail())
                 .avatarUrl(account.getAvatarUrl())
+                .role(account.getLibraryRole())
+                .requested(account.isRoleRequest())
                 .rentalBookResponses(rentalBookResponses)
                 .build();
     }

--- a/src/main/java/kr/codesquad/library/domain/account/response/RoleRequestResponse.java
+++ b/src/main/java/kr/codesquad/library/domain/account/response/RoleRequestResponse.java
@@ -1,0 +1,28 @@
+package kr.codesquad.library.domain.account.response;
+
+import kr.codesquad.library.domain.account.Account;
+import kr.codesquad.library.domain.account.LibraryRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RoleRequestResponse {
+    private final String name;
+    private final LibraryRole role;
+    private final boolean requested;
+
+    @Builder
+    private RoleRequestResponse(String name, LibraryRole role, boolean requested) {
+        this.name = name;
+        this.role = role;
+        this.requested = requested;
+    }
+
+    public static RoleRequestResponse of(Account account, boolean requested) {
+        return RoleRequestResponse.builder()
+                .name(account.getName())
+                .role(account.getLibraryRole())
+                .requested(requested)
+                .build();
+    }
+}

--- a/src/main/java/kr/codesquad/library/global/config/oauth/security/CustomOAuth2UserService.java
+++ b/src/main/java/kr/codesquad/library/global/config/oauth/security/CustomOAuth2UserService.java
@@ -66,6 +66,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 .email(userInfo.getEmail())
                 .avatarUrl(userInfo.getAvatarUrl())
                 .libraryRole(LibraryRole.GUEST)
+                .roleRequest(false)
                 .build();
     }
 }

--- a/src/main/java/kr/codesquad/library/global/config/oauth/security/ProviderAttributes.java
+++ b/src/main/java/kr/codesquad/library/global/config/oauth/security/ProviderAttributes.java
@@ -1,6 +1,6 @@
 package kr.codesquad.library.global.config.oauth.security;
 
-import kr.codesquad.library.global.error.exception.domain.ProviderNotExistException;
+import kr.codesquad.library.global.error.exception.oauth.ProviderNotExistException;
 import lombok.Getter;
 
 import java.util.stream.Stream;

--- a/src/main/java/kr/codesquad/library/global/error/ErrorCode.java
+++ b/src/main/java/kr/codesquad/library/global/error/ErrorCode.java
@@ -21,13 +21,13 @@ public enum ErrorCode {
     OUT_OF_BOOK(400, "B004", "해당 도서는 대여중입니다."),
     MAX_RENTAL_BOOK(400, "B005", "대여도서 수가 최대치입니다."),
     RENTAL_NOT_FOUND(404, "B006", "해당 대여는 없습니다."),
-    ALREADY_RETURN_BOOK(400, "B007", "이미 반납한 도서입니다."),
+    REDUNDANT_RETURN_BOOK(400, "B007", "이미 반납한 도서입니다."),
 
     // Account
     ACCOUNT_NOT_FOUND(404, "A001", "해당 계정은 없습니다."),
     ACCOUNT_LOGOUT(400, "A002", "로그인이 필요합니다."),
-    PROVIDER_NOT_FOUND(404, "A003", "존재하지 않는 OAuth 제공자 입니다.")
-
+    PROVIDER_NOT_FOUND(404, "A003", "존재하지 않는 OAuth 제공자 입니다."),
+    BAD_REQUEST_AUTHORIZATION(400, "A005", "잘못된 권한 신청입니다."),
 
     ;
 

--- a/src/main/java/kr/codesquad/library/global/error/exception/domain/BadRequestAuthorizationException.java
+++ b/src/main/java/kr/codesquad/library/global/error/exception/domain/BadRequestAuthorizationException.java
@@ -3,8 +3,8 @@ package kr.codesquad.library.global.error.exception.domain;
 import kr.codesquad.library.global.error.ErrorCode;
 import kr.codesquad.library.global.error.exception.BusinessException;
 
-public class ProviderNotExistException extends BusinessException {
-    public ProviderNotExistException() {
-        super(ErrorCode.PROVIDER_NOT_FOUND);
+public class BadRequestAuthorizationException extends BusinessException {
+    public BadRequestAuthorizationException() {
+        super(ErrorCode.BAD_REQUEST_AUTHORIZATION);
     }
 }

--- a/src/main/java/kr/codesquad/library/global/error/exception/domain/RedundantRequestBookException.java
+++ b/src/main/java/kr/codesquad/library/global/error/exception/domain/RedundantRequestBookException.java
@@ -3,8 +3,8 @@ package kr.codesquad.library.global.error.exception.domain;
 import kr.codesquad.library.global.error.ErrorCode;
 import kr.codesquad.library.global.error.exception.BusinessException;
 
-public class AlreadyReturnBookException extends BusinessException {
-    public AlreadyReturnBookException() {
-        super(ErrorCode.ALREADY_RETURN_BOOK);
+public class RedundantRequestBookException extends BusinessException {
+    public RedundantRequestBookException() {
+        super(ErrorCode.REDUNDANT_RETURN_BOOK);
     }
 }

--- a/src/main/java/kr/codesquad/library/global/error/exception/oauth/ProviderNotExistException.java
+++ b/src/main/java/kr/codesquad/library/global/error/exception/oauth/ProviderNotExistException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.library.global.error.exception.oauth;
+
+import kr.codesquad.library.global.error.ErrorCode;
+import kr.codesquad.library.global.error.exception.BusinessException;
+
+public class ProviderNotExistException extends BusinessException {
+    public ProviderNotExistException() {
+        super(ErrorCode.PROVIDER_NOT_FOUND);
+    }
+}

--- a/src/main/java/kr/codesquad/library/service/AccountService.java
+++ b/src/main/java/kr/codesquad/library/service/AccountService.java
@@ -4,11 +4,13 @@ import kr.codesquad.library.domain.account.Account;
 import kr.codesquad.library.domain.account.AccountRepository;
 import kr.codesquad.library.domain.account.response.AccountMyPageResponse;
 import kr.codesquad.library.domain.account.response.AccountProfileResponse;
+import kr.codesquad.library.domain.account.response.RoleRequestResponse;
 import kr.codesquad.library.domain.book.Book;
 import kr.codesquad.library.domain.rental.Rental;
 import kr.codesquad.library.domain.rental.RentalRepository;
 import kr.codesquad.library.domain.rental.response.RentalBookResponse;
 import kr.codesquad.library.global.error.exception.domain.AccountNotFoundException;
+import kr.codesquad.library.global.error.exception.domain.BadRequestAuthorizationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static kr.codesquad.library.domain.account.LibraryRole.*;
 
 @RequiredArgsConstructor
 @Service
@@ -41,5 +45,16 @@ public class AccountService {
     public AccountProfileResponse getProfile(Long accountId) {
         Account account = accountRepository.findById(accountId).orElseThrow(AccountNotFoundException::new);
         return AccountProfileResponse.of(account);
+    }
+
+    @Transactional
+    public RoleRequestResponse requestAuthority(Long accountId) {
+        Account account = accountRepository.findById(accountId).orElseThrow(AccountNotFoundException::new);
+
+        if (account.getLibraryRole() != GUEST || account.isRoleRequest()) {
+            throw new BadRequestAuthorizationException();
+        }
+
+        return RoleRequestResponse.of(account, account.requestUserRole());
     }
 }

--- a/src/main/java/kr/codesquad/library/service/BookService.java
+++ b/src/main/java/kr/codesquad/library/service/BookService.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -126,7 +125,7 @@ public class BookService {
         Rental rental = rentalRepository.findByBookAndAccountAndIsReturnedFalse(book, account).orElseThrow(RentalNotFoundException::new);
 
         if (rental.isReturned()) {
-            throw new AlreadyReturnBookException();
+            throw new RedundantRequestBookException();
         }
 
         rental.returnBook();

--- a/src/test/java/kr/codesquad/library/service/AccountServiceTest.java
+++ b/src/test/java/kr/codesquad/library/service/AccountServiceTest.java
@@ -2,6 +2,7 @@ package kr.codesquad.library.service;
 
 import kr.codesquad.library.domain.account.Account;
 import kr.codesquad.library.domain.account.AccountRepository;
+import kr.codesquad.library.domain.account.LibraryRole;
 import kr.codesquad.library.domain.account.response.AccountMyPageResponse;
 import kr.codesquad.library.domain.account.response.AccountProfileResponse;
 import kr.codesquad.library.domain.book.Book;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+// AccountId = {(1 == GUEST), (2 == USER), (3 == ADMIN)}
 @SpringBootTest
 class AccountServiceTest {
 
@@ -49,6 +51,7 @@ class AccountServiceTest {
         //then
         assertAll(
                 () -> assertThat(myPage).isNotNull(),
+                () -> assertThat(myPage.getRole()).isEqualTo(LibraryRole.USER),
                 () -> assertThat(myPage.getRentalBookResponses()).isNotEmpty(),
                 () -> assertThat(myPage.getRentalBookResponses().size()).isEqualTo(size),
                 () -> assertThat(bookTitle).isEqualTo(book.getTitle())
@@ -69,6 +72,47 @@ class AccountServiceTest {
         assertAll(
                 () -> assertThat(profile.getName()).isEqualTo(account.getName()),
                 () -> assertThat(profile.getAvatarUrl()).isEqualTo(account.getAvatarUrl())
+        );
+    }
+
+    @CsvSource({"1"})
+    @ParameterizedTest
+    @Transactional
+    public void 권한요청하기_WITH_GUEST(Long accountId) {
+        //given
+        Account account = accountRepository.findById(accountId).orElseThrow(AccountNotFoundException::new);
+
+        //when
+        accountService.requestAuthority(account.getId());
+        AccountMyPageResponse myPage = AccountMyPageResponse.of(account, null);
+
+        //then
+        assertAll(
+                () -> assertThat(account.isRoleRequest()).isTrue(),
+                () -> assertThat(myPage.isRequested()).isTrue()
+        );
+    }
+
+    @CsvSource({"2, 3"})
+    @ParameterizedTest
+    @Transactional
+    public void 권한요청하기_WITH_USER_ADMIN(Long userId, Long adminId) {
+        //given
+        Account user = accountRepository.findById(userId).orElseThrow(AccountNotFoundException::new);
+        Account admin = accountRepository.findById(adminId).orElseThrow(AccountNotFoundException::new);
+
+        //when
+        accountService.requestAuthority(user.getId());
+        AccountMyPageResponse userPage = AccountMyPageResponse.of(user, null);
+        accountService.requestAuthority(admin.getId());
+        AccountMyPageResponse adminPage = AccountMyPageResponse.of(admin, null);
+
+        //then
+        assertAll(
+                () -> assertThat(user.isRoleRequest()).isFalse(),
+                () -> assertThat(admin.isRoleRequest()).isFalse(),
+                () -> assertThat(userPage.isRequested()).isFalse(),
+                () -> assertThat(adminPage.isRequested()).isFalse()
         );
     }
 }


### PR DESCRIPTION
- AccountController
  - handleAccountException(): 로그아웃상태 일 때 발생하는 Exception은 NullPointException 이라서 변경.

- AccountMyPageResponse: 사용자의 권한 및 권한 요청 필드값 추가.
- RoleRequestResponse: 사용자가 권한 요청할 때 사용자의 권한 및 권한 요청값을 리턴.

- Account
  - roleRequest: 권한 요청 여부 추가.

- RedundantRequestBookException: Already는 변수명에는 부적절하다고 피드백.

- AccountService
  - requestAuthority(): GUEST가 아니거나, 이미 요청한 사용자는 예외처리. GUEST인 사용자는 관리자에게 USER Role 요청함.