### PR TITLE
[Server] refactor: 복수형일 때 findAll로 변경.

### DIFF
--- a/src/main/java/kr/codesquad/library/domain/book/BookRepository.java
+++ b/src/main/java/kr/codesquad/library/domain/book/BookRepository.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    Page<Book> findByCategoryId(Long categoryId, Pageable pageable);
+    Page<Book> findAllByCategoryId(Long categoryId, Pageable pageable);
 
     List<Book> findTop6ByCategoryIdAndImageUrlIsNotNullOrderByRecommendCountDesc(Long categoryId);
 
-    Page<Book> findByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(String title, String author, Pageable pageable);
+    Page<Book> findAllByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(String title, String author, Pageable pageable);
 }

--- a/src/main/java/kr/codesquad/library/domain/rental/RentalRepository.java
+++ b/src/main/java/kr/codesquad/library/domain/rental/RentalRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface RentalRepository extends JpaRepository<Rental, Long> {
 
-    List<Rental> findByAccountAndIsReturnedFalse(Account account);
+    List<Rental> findAllByAccountAndIsReturnedFalse(Account account);
 
     Optional<Rental> findByBookAndAccountAndIsReturnedFalse(Book book, Account account);
 }

--- a/src/main/java/kr/codesquad/library/domain/rental/firstclass/Rentals.java
+++ b/src/main/java/kr/codesquad/library/domain/rental/firstclass/Rentals.java
@@ -24,15 +24,7 @@ public class Rentals {
         return rentals.isEmpty() ? null : rentals.get(drawRentalListByBook(book));
     }
 
-    public Rental findByAccount(Account account) {
-        return rentals.isEmpty() ? null : rentals.get(drawRentalListByAccount(account));
-    }
-
     private int drawRentalListByBook(Book book) {
         return book.getRentals().size() - 1;
-    }
-
-    private int drawRentalListByAccount(Account account) {
-        return account.getRentals().size() - 1;
     }
 }

--- a/src/main/java/kr/codesquad/library/service/AccountService.java
+++ b/src/main/java/kr/codesquad/library/service/AccountService.java
@@ -27,7 +27,7 @@ public class AccountService {
 
     public AccountMyPageResponse getMyPage(Long accountId) {
         Account account = accountRepository.findById(accountId).orElseThrow(AccountNotFoundException::new);
-        List<Rental> rentalList = rentalRepository.findByAccountAndIsReturnedFalse(account);
+        List<Rental> rentalList = rentalRepository.findAllByAccountAndIsReturnedFalse(account);
         List<Book> bookList = rentalList.stream().map(Rental::getBook).collect(Collectors.toList());
         List<RentalBookResponse> rentalBookResponses = new ArrayList<>();
 

--- a/src/main/java/kr/codesquad/library/service/BookService.java
+++ b/src/main/java/kr/codesquad/library/service/BookService.java
@@ -70,12 +70,12 @@ public class BookService {
                 .categoryId(categoryId)
                 .categoryTitle(category.getTitle())
                 .bookCount(category.getBooks().size())
-                .books(findByCategoryIdBooks(categoryId, page))
+                .books(findBooksByCategoryId(categoryId, page))
                 .build();
     }
 
-    public List<BookResponse> findByCategoryIdBooks(Long categoryId, int page) {
-        Page<Book> bookPage = bookRepository.findByCategoryId(categoryId, getPageRequest(page));
+    public List<BookResponse> findBooksByCategoryId(Long categoryId, int page) {
+        Page<Book> bookPage = bookRepository.findAllByCategoryId(categoryId, getPageRequest(page));
         List<Book> bookList = bookPage.getContent();
 
         return bookList.stream().map(BookResponse::of).collect(Collectors.toList());
@@ -91,7 +91,7 @@ public class BookService {
 
     public BookSearchResponse searchBooks(String searchWord, int page) {
         Page<Book> bookPage = bookRepository
-                .findByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(searchWord, searchWord, getPageRequest(page));
+                .findAllByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(searchWord, searchWord, getPageRequest(page));
         List<Book> bookList = bookPage.getContent();
         List<BookResponse> bookResponseList = bookList.stream().map(BookResponse::of).collect(Collectors.toList());
 
@@ -109,7 +109,7 @@ public class BookService {
         if (!book.isAvailable()) {
             throw new OutOfBookException();
         }
-        if (rentalRepository.findByAccountAndIsReturnedFalse(account).size() >= MAX_RENTAL_SIZE) {
+        if (rentalRepository.findAllByAccountAndIsReturnedFalse(account).size() >= MAX_RENTAL_SIZE) {
             throw new MaxRentalViolationException();
         }
 

--- a/src/test/java/kr/codesquad/library/domain/book/BookRepositoryTest.java
+++ b/src/test/java/kr/codesquad/library/domain/book/BookRepositoryTest.java
@@ -75,7 +75,7 @@ class BookRepositoryTest {
     public void 첫번째_카테고리페이지가져오기(int page, int size, Long categoryId, String property) {
         PageRequest pageRequest = getPageRequest(page, size, property);
 
-        Page<Book> page1 = books.findByCategoryId(categoryId, pageRequest);
+        Page<Book> page1 = books.findAllByCategoryId(categoryId, pageRequest);
 
         assertThat(page1.getTotalElements()).isEqualTo(39);
         assertThat(page1.getTotalPages()).isEqualTo(2);
@@ -87,7 +87,7 @@ class BookRepositoryTest {
     @ParameterizedTest
     public void 검색_실패(int page, int size, String property, String title) throws Exception {
         //when
-        Page<Book> bookPage = books.findByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(title, title, getPageRequest(page, size, property));
+        Page<Book> bookPage = books.findAllByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(title, title, getPageRequest(page, size, property));
         List<Book> bookList = bookPage.getContent();
         //then
         assertThat(bookList).isEmpty();
@@ -97,7 +97,7 @@ class BookRepositoryTest {
     @ParameterizedTest
     public void 도서제목_저자_검색(int page, int size, String property, String title, int bookCount) throws Exception {
         //when
-        Page<Book> bookPage = books.findByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(title, title, getPageRequest(page, size, property));
+        Page<Book> bookPage = books.findAllByTitleIgnoreCaseContainingOrAuthorIgnoreCaseContaining(title, title, getPageRequest(page, size, property));
         List<Book> bookList = bookPage.getContent();
 
         //then

--- a/src/test/java/kr/codesquad/library/service/BookServiceTest.java
+++ b/src/test/java/kr/codesquad/library/service/BookServiceTest.java
@@ -55,7 +55,7 @@ class BookServiceTest {
     public void 각_카테고리별_도서를_페이지씩_가져온다(Long categoryId, int page) {
 
         //when
-        List<BookResponse> books = bookService.findByCategoryIdBooks(categoryId, page);
+        List<BookResponse> books = bookService.findBooksByCategoryId(categoryId, page);
 
         //then
         assertThat(books.size()).isEqualTo(20);


### PR DESCRIPTION
- BookRepository
  - findTop6ByCategoryIdAndImageUrlIsNotNullOrderByRecommendCountDesc(): 이 메서드는 findAll로 할 경우 Top6 반영이 되지않아 그대로 둠.

- Rentals
  - findByAccount(): 미사용으로 삭제.

- BookService
  - findBooksByCategoryId(): 통일성을 위한 메서드명 변경. 끝에 Books가 아닌, find에 대한 Object 명확히 표시.