### PR TITLE
[HotFix] 도서 검색 결과 출력시 다음 페이지 요청할 경우 제대로 처리되지 않던 오류 수정

### DIFF
--- a/src/main/java/kr/codesquad/library/admin/controller/BookAdminController.java
+++ b/src/main/java/kr/codesquad/library/admin/controller/BookAdminController.java
@@ -35,7 +35,8 @@ public class BookAdminController {
         BookSummaryResponse books = bookAdminService.searchBooks(page, name);
         model.addAttribute("bookSummaries", books.getBookSummaries());
         model.addAttribute("pagingProperties", books.getPagingProperties());
-        return "book/books-all";
+        model.addAttribute("searchTitle", name);
+        return "book/books-searchall";
     }
 
     @PostMapping("")

--- a/src/main/resources/templates/book/books-searchall.html
+++ b/src/main/resources/templates/book/books-searchall.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>CODESQUAD LIBRARY - ADMIN</title>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/styles.css}"/>
+    <link rel="stylesheet" type="text/css" th:href="@{https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.css}" />
+    <script th:src="@{https://kit.fontawesome.com/1099c14a72.js}" crossorigin="anonymous"></script>
+    <script th:src="@{https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js}"></script>
+</head>
+<body>
+<header class="header">
+    <div class="container">
+        <div class="header__box">
+            <a th:href="@{/admin/users/guest}" class="site-link">
+                <div class="site-title">
+                    <img th:src="@{/images/logo.png}" alt="CODE SQUAD" class="site-title__logo">
+                    <div class="site-title__column">
+                        <h1 class="site-title__main-text">
+                            CODESQUAD LIBRARY
+                        </h1>
+                        <h2 class="site-title__sub-text">ADMIN</h2>
+                    </div>
+                </div>
+            </a>
+            <ul class="navigation">
+                <li class="navigation__item"><a th:href="@{/admin/users}">회원 관리</a></li>
+                <li class="navigation__item navigation__item--clicked"><a th:href="@{/admin/books}">도서 관리</a></li>
+                <li class="navigation__item"><a th:href="@{/admin/category}">카테고리 관리</a></li>
+                <li class="navigation__item"><a th:href="@{/admin/bookcase}">도서위치 관리</a></li>
+            </ul>
+            <div class="user-info">
+                <img th:src="@{/images/logo.png}" alt="USER IMAGE" class="user-info__image">
+                <span class="user-info__name">USER_NAME</span>
+            </div>
+        </div>
+        <ul class="sub-navigation">
+            <li class="sub-navigation__item sub-navigation__item--clicked"><a th:href="@{/admin/books}"><i class="fas fa-list-ol sub-navigation__icon"></i> <span class="sub-navigation__title">도서 목록</span></a></li>
+            <li class="sub-navigation__item"><a th:href="@{/admin/books/open_api/search_form}"><i class="fas fa-pen-square sub-navigation__icon"></i> <span class="sub-navigation__title">도서 등록</span></a></li>
+        </ul>
+    </div>
+</header>
+<div class="main">
+    <div class="container">
+        <div class="main-contents">
+            <h2 class="main-contents__navigation-title">도서 목록</h2>
+            <form th:action="@{/admin/books/search}" class="search-form" method="get">
+                <div class="search-form__box">
+                    <input type="search" name="title" class="search-form__bar" placeholder="검색할 책의 제목을 입력하세요."/>
+                    <i class="fas fa-search search-form__icon"></i>
+                </div>
+            </form>
+            <table class="book-table">
+                <thead>
+                <tr>
+                    <th class="book-table__column-name">ID</th>
+                    <th class="book-table__column-name">제목</th>
+                    <th class="book-table__column-name">카테고리</th>
+                    <th class="book-table__column-name">위치</th>
+                    <th class="book-table__column-name">ISBN</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="bookSummary : ${bookSummaries}">
+                    <td th:text="${bookSummary.id}" class="book-table__row jsData jsDataId"></td>
+                    <td th:text="${bookSummary.title}" class="book-table__row jsData"></td>
+                    <td th:text="${bookSummary.categoryTitle}" class="book-table__row jsData"></td>
+                    <td th:text="${bookSummary.location}" class="book-table__row jsData"></td>
+                    <td th:text="${bookSummary.isbn}" class="book-table__row jsData"></td>
+                </tr>
+                </tbody>
+            </table>
+            <ol class="paging-numbers"
+                th:with="start=${pagingProperties.startPageOfPageGroup}, end=${pagingProperties.endPageOfPageGroup}">
+                <li class="paging-numbers__number">
+                    <a th:href="@{search(title=${searchTitle}, page=1)}"><i class="fas fa-angle-double-left"></i></a>
+                </li>
+                <li class="paging-numbers__number">
+                    <a th:href="@{search(title=${searchTitle}, page=${pagingProperties.endPageOfPreviousPageGroup})}"><i class="fas fa-angle-left"></i></a>
+                </li>
+                <li class="paging-numbers__number" th:each="page : ${#numbers.sequence(start, end)}" th:classappend="${page == pagingProperties.currentPage} ? 'paging-numbers__number--clicked'">
+                    <a th:href="@{search(title=${searchTitle}, page=${page})}" th:text="${page}"></a>
+                </li>
+                <li class="paging-numbers__number">
+                    <a th:href="@{search(title=${searchTitle}, page=${pagingProperties.startPageOfNextPageGroup})}"><i class="fas fa-angle-right"></i></a>
+                </li>
+                <li class="paging-numbers__number">
+                    <a th:href="@{search(title=${searchTitle}, page=${pagingProperties.totalPages})}"><i class="fas fa-angle-double-right"></i></a>
+                </li>
+            </ol>
+        </div>
+    </div>
+</div>
+<footer class="footer">
+    <div class="container">
+        <p class="copyright-text">Copyright © 2020. Codesquad Library. All rights reserved</p>
+        <p class="copyright-author">Ragdoll @CODESQUAD</p>
+    </div>
+</footer>
+<script type="text/javascript" th:src="@{/js/dataTableHandler.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
templates/books-searchall
- 페이지 요청 URL을 기존 도서 목록의 페이지 요청과 분리하기 위해 별도로 뷰 생성

BookAdminController
- searchBooks() : 검색 제목 값을 뷰로 넘겨주기 위해 searchTitle 데이터 추가